### PR TITLE
Update minor versions of dependencies

### DIFF
--- a/.github/workflows/publish_docker_3key.yml
+++ b/.github/workflows/publish_docker_3key.yml
@@ -16,7 +16,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Install Cosign
-        uses: sigstore/cosign-installer@v3.5.0
+        uses: sigstore/cosign-installer@v3.6.0
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3

--- a/.github/workflows/publish_docker_3key.yml
+++ b/.github/workflows/publish_docker_3key.yml
@@ -42,7 +42,7 @@ jobs:
             type=sha,prefix=develop-,format=long
 
       - name: Build and push Docker image
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@v6
         id: build-and-push
         with:
           context: .

--- a/.github/workflows/publish_docker_czertainly.yml
+++ b/.github/workflows/publish_docker_czertainly.yml
@@ -16,7 +16,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Install Cosign
-        uses: sigstore/cosign-installer@v3.5.0
+        uses: sigstore/cosign-installer@v3.6.0
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3

--- a/.github/workflows/publish_docker_czertainly.yml
+++ b/.github/workflows/publish_docker_czertainly.yml
@@ -42,7 +42,7 @@ jobs:
             type=sha,prefix=develop-,format=long
 
       - name: Build and push Docker image
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@v6
         id: build-and-push
         with:
           context: .

--- a/.github/workflows/publish_harbor_3key.yml
+++ b/.github/workflows/publish_harbor_3key.yml
@@ -16,7 +16,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Install Cosign
-        uses: sigstore/cosign-installer@v3.5.0
+        uses: sigstore/cosign-installer@v3.6.0
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3

--- a/.github/workflows/publish_harbor_3key.yml
+++ b/.github/workflows/publish_harbor_3key.yml
@@ -43,7 +43,7 @@ jobs:
             type=sha,prefix=develop-,format=long
 
       - name: Build and push Docker image
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@v6
         id: build-and-push
         with:
           context: .

--- a/package-lock.json
+++ b/package-lock.json
@@ -10078,12 +10078,13 @@
             }
         },
         "node_modules/husky": {
-            "version": "9.0.11",
-            "resolved": "https://registry.npmjs.org/husky/-/husky-9.0.11.tgz",
-            "integrity": "sha512-AB6lFlbwwyIqMdHYhwPe+kjOC3Oc5P3nThEoW/AaO2BX3vJDjWPFxYLxokUZOo6RNX20He3AaT8sESs9NJcmEw==",
+            "version": "9.1.4",
+            "resolved": "https://registry.npmjs.org/husky/-/husky-9.1.4.tgz",
+            "integrity": "sha512-bho94YyReb4JV7LYWRWxZ/xr6TtOTt8cMfmQ39MQYJ7f/YE268s3GdghGwi+y4zAeqewE5zYLvuhV0M0ijsDEA==",
             "dev": true,
+            "license": "MIT",
             "bin": {
-                "husky": "bin.mjs"
+                "husky": "bin.js"
             },
             "engines": {
                 "node": ">=18"

--- a/package-lock.json
+++ b/package-lock.json
@@ -8288,13 +8288,14 @@
             }
         },
         "node_modules/eslint-plugin-prettier": {
-            "version": "5.1.3",
-            "resolved": "https://registry.npmjs.org/eslint-plugin-prettier/-/eslint-plugin-prettier-5.1.3.tgz",
-            "integrity": "sha512-C9GCVAs4Eq7ZC/XFQHITLiHJxQngdtraXaM+LoUFoFp/lHNl2Zn8f3WQbe9HvTBBQ9YnKFB0/2Ajdqwo5D1EAw==",
+            "version": "5.2.1",
+            "resolved": "https://registry.npmjs.org/eslint-plugin-prettier/-/eslint-plugin-prettier-5.2.1.tgz",
+            "integrity": "sha512-gH3iR3g4JfF+yYPaJYkN7jEl9QbweL/YfkoRlNnuIEHEz1vHVlCmWOS+eGGiRuzHQXdJFCOTxRgvju9b8VUmrw==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
                 "prettier-linter-helpers": "^1.0.0",
-                "synckit": "^0.8.6"
+                "synckit": "^0.9.1"
             },
             "engines": {
                 "node": "^14.18.0 || >=16.0.0"
@@ -17601,10 +17602,11 @@
             "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw=="
         },
         "node_modules/synckit": {
-            "version": "0.8.8",
-            "resolved": "https://registry.npmjs.org/synckit/-/synckit-0.8.8.tgz",
-            "integrity": "sha512-HwOKAP7Wc5aRGYdKH+dw0PRRpbO841v2DENBtjnR5HFWoiNByAl7vrx3p0G/rCyYXQsrxqtX48TImFtPcIHSpQ==",
+            "version": "0.9.1",
+            "resolved": "https://registry.npmjs.org/synckit/-/synckit-0.9.1.tgz",
+            "integrity": "sha512-7gr8p9TQP6RAHusBOSLs46F4564ZrjV8xFmw5zCmgmhGUcw2hxsShhJ6CEiHQMgPDwAQ1fWHPM0ypc4RMAig4A==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
                 "@pkgr/core": "^0.1.0",
                 "tslib": "^2.6.2"

--- a/package-lock.json
+++ b/package-lock.json
@@ -9817,9 +9817,10 @@
             }
         },
         "node_modules/highlight.js": {
-            "version": "11.9.0",
-            "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-11.9.0.tgz",
-            "integrity": "sha512-fJ7cW7fQGCYAkgv4CPfwFHrfd/cLS4Hau96JuJ+ZTOWhjnhoeN1ub1tFmALm/+lW5z4WCAuAV9bm05AP0mS6Gw==",
+            "version": "11.10.0",
+            "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-11.10.0.tgz",
+            "integrity": "sha512-SYVnVFswQER+zu1laSya563s+F8VDGt7o35d4utbamowvUNLLMovFqwCLSocpZTz3MgaSRA1IbqRWZv97dtErQ==",
+            "license": "BSD-3-Clause",
             "engines": {
                 "node": ">=12.0.0"
             }

--- a/package-lock.json
+++ b/package-lock.json
@@ -6458,9 +6458,10 @@
             }
         },
         "node_modules/cronstrue": {
-            "version": "2.49.0",
-            "resolved": "https://registry.npmjs.org/cronstrue/-/cronstrue-2.49.0.tgz",
-            "integrity": "sha512-FWZBqdStQaPR8ZTBQGALh1EK9Hl1HcG70dyGvD1rKLPafFO3H73o38dz/e8YkIlbLn3JxmBI/f6Doe3Nh+DcEQ==",
+            "version": "2.50.0",
+            "resolved": "https://registry.npmjs.org/cronstrue/-/cronstrue-2.50.0.tgz",
+            "integrity": "sha512-ULYhWIonJzlScCCQrPUG5uMXzXxSixty4djud9SS37DoNxDdkeRocxzHuAo4ImRBUK+mAuU5X9TSwEDccnnuPg==",
+            "license": "MIT",
             "bin": {
                 "cronstrue": "bin/cli.js"
             }

--- a/package-lock.json
+++ b/package-lock.json
@@ -4868,14 +4868,6 @@
                 "sprintf-js": "~1.0.2"
             }
         },
-        "node_modules/aria-query": {
-            "version": "5.3.0",
-            "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.3.0.tgz",
-            "integrity": "sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==",
-            "dependencies": {
-                "dequal": "^2.0.3"
-            }
-        },
         "node_modules/array-buffer-byte-length": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/array-buffer-byte-length/-/array-buffer-byte-length-1.0.1.tgz",
@@ -5125,9 +5117,10 @@
             "dev": true
         },
         "node_modules/axe-core": {
-            "version": "4.7.0",
-            "resolved": "https://registry.npmjs.org/axe-core/-/axe-core-4.7.0.tgz",
-            "integrity": "sha512-M0JtH+hlOL5pLQwHOLNYZaXuhqmvS8oExsqB1SBYgA4Dk7u/xx+YdGHXaK5pyUfed5mYXdlYiphWq3G8cRi5JQ==",
+            "version": "4.10.0",
+            "resolved": "https://registry.npmjs.org/axe-core/-/axe-core-4.10.0.tgz",
+            "integrity": "sha512-Mr2ZakwQ7XUAjp7pAwQWRhhK8mQQ6JAaNWSjmjxil0R8BPioMtQsTLOolGYkji1rcL++3dCqZA3zWqpT+9Ew6g==",
+            "license": "MPL-2.0",
             "engines": {
                 "node": ">=4"
             }
@@ -5159,14 +5152,6 @@
             "version": "1.1.0",
             "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
             "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg=="
-        },
-        "node_modules/axobject-query": {
-            "version": "3.2.1",
-            "resolved": "https://registry.npmjs.org/axobject-query/-/axobject-query-3.2.1.tgz",
-            "integrity": "sha512-jsyHu61e6N4Vbz/v18DHwWYKK0bSWLqn47eeDSKPB7m8tqMHF9YJ+mhIk2lVteyZrY8tnSj/jHOv4YiTCuCJgg==",
-            "dependencies": {
-                "dequal": "^2.0.3"
-            }
         },
         "node_modules/babel-jest": {
             "version": "27.5.1",
@@ -7350,6 +7335,38 @@
             "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.4.3.tgz",
             "integrity": "sha512-VBBaLc1MgL5XpzgIP7ny5Z6Nx3UrRkIViUkPUdtl9aya5amy3De1gsUUSB1g3+3sExYNjCAsAznmukyxCb1GRA=="
         },
+        "node_modules/deep-equal": {
+            "version": "2.2.3",
+            "resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-2.2.3.tgz",
+            "integrity": "sha512-ZIwpnevOurS8bpT4192sqAowWM76JDKSHYzMLty3BZGSswgq6pBaH3DhCSW5xVAZICZyKdOBPjwww5wfgT/6PA==",
+            "license": "MIT",
+            "dependencies": {
+                "array-buffer-byte-length": "^1.0.0",
+                "call-bind": "^1.0.5",
+                "es-get-iterator": "^1.1.3",
+                "get-intrinsic": "^1.2.2",
+                "is-arguments": "^1.1.1",
+                "is-array-buffer": "^3.0.2",
+                "is-date-object": "^1.0.5",
+                "is-regex": "^1.1.4",
+                "is-shared-array-buffer": "^1.0.2",
+                "isarray": "^2.0.5",
+                "object-is": "^1.1.5",
+                "object-keys": "^1.1.1",
+                "object.assign": "^4.1.4",
+                "regexp.prototype.flags": "^1.5.1",
+                "side-channel": "^1.0.4",
+                "which-boxed-primitive": "^1.0.2",
+                "which-collection": "^1.0.1",
+                "which-typed-array": "^1.1.13"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
         "node_modules/deep-is": {
             "version": "0.1.4",
             "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
@@ -7447,14 +7464,6 @@
             "integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==",
             "engines": {
                 "node": ">= 0.8"
-            }
-        },
-        "node_modules/dequal": {
-            "version": "2.0.3",
-            "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
-            "integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
-            "engines": {
-                "node": ">=6"
             }
         },
         "node_modules/destroy": {
@@ -7817,9 +7826,10 @@
             }
         },
         "node_modules/es-abstract": {
-            "version": "1.23.2",
-            "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.23.2.tgz",
-            "integrity": "sha512-60s3Xv2T2p1ICykc7c+DNDPLDMm9t4QxCOUU0K9JxiLjM3C1zB9YVdN7tjxrFd4+AkZ8CdX1ovUga4P2+1e+/w==",
+            "version": "1.23.3",
+            "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.23.3.tgz",
+            "integrity": "sha512-e+HfNH61Bj1X9/jLc5v1owaLYuHdeHHSQlkhCBiTK8rBvKaULl/beGMxwrMXjpYrv4pz22BlY570vVePA2ho4A==",
+            "license": "MIT",
             "dependencies": {
                 "array-buffer-byte-length": "^1.0.1",
                 "arraybuffer.prototype.slice": "^1.0.3",
@@ -7860,11 +7870,11 @@
                 "safe-regex-test": "^1.0.3",
                 "string.prototype.trim": "^1.2.9",
                 "string.prototype.trimend": "^1.0.8",
-                "string.prototype.trimstart": "^1.0.7",
+                "string.prototype.trimstart": "^1.0.8",
                 "typed-array-buffer": "^1.0.2",
                 "typed-array-byte-length": "^1.0.1",
                 "typed-array-byte-offset": "^1.0.2",
-                "typed-array-length": "^1.0.5",
+                "typed-array-length": "^1.0.6",
                 "unbox-primitive": "^1.0.2",
                 "which-typed-array": "^1.1.15"
             },
@@ -7899,14 +7909,35 @@
                 "node": ">= 0.4"
             }
         },
+        "node_modules/es-get-iterator": {
+            "version": "1.1.3",
+            "resolved": "https://registry.npmjs.org/es-get-iterator/-/es-get-iterator-1.1.3.tgz",
+            "integrity": "sha512-sPZmqHBe6JIiTfN5q2pEi//TwxmAFHwj/XEuYjTuse78i8KxaqMTTzxPoFKuzRpDpTJ+0NAbpfenkmH2rePtuw==",
+            "license": "MIT",
+            "dependencies": {
+                "call-bind": "^1.0.2",
+                "get-intrinsic": "^1.1.3",
+                "has-symbols": "^1.0.3",
+                "is-arguments": "^1.1.1",
+                "is-map": "^2.0.2",
+                "is-set": "^2.0.2",
+                "is-string": "^1.0.7",
+                "isarray": "^2.0.5",
+                "stop-iteration-iterator": "^1.0.0"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
         "node_modules/es-iterator-helpers": {
-            "version": "1.0.18",
-            "resolved": "https://registry.npmjs.org/es-iterator-helpers/-/es-iterator-helpers-1.0.18.tgz",
-            "integrity": "sha512-scxAJaewsahbqTYrGKJihhViaM6DDZDDoucfvzNbK0pOren1g/daDQ3IAhzn+1G14rBG7w+i5N+qul60++zlKA==",
+            "version": "1.0.19",
+            "resolved": "https://registry.npmjs.org/es-iterator-helpers/-/es-iterator-helpers-1.0.19.tgz",
+            "integrity": "sha512-zoMwbCcH5hwUkKJkT8kDIBZSz9I6mVG//+lDCinLCGov4+r7NIy0ld8o03M0cJxl2spVf6ESYVS6/gpIfq1FFw==",
+            "license": "MIT",
             "dependencies": {
                 "call-bind": "^1.0.7",
                 "define-properties": "^1.2.1",
-                "es-abstract": "^1.23.0",
+                "es-abstract": "^1.23.3",
                 "es-errors": "^1.3.0",
                 "es-set-tostringtag": "^2.0.3",
                 "function-bind": "^1.1.2",
@@ -8259,32 +8290,51 @@
             }
         },
         "node_modules/eslint-plugin-jsx-a11y": {
-            "version": "6.8.0",
-            "resolved": "https://registry.npmjs.org/eslint-plugin-jsx-a11y/-/eslint-plugin-jsx-a11y-6.8.0.tgz",
-            "integrity": "sha512-Hdh937BS3KdwwbBaKd5+PLCOmYY6U4f2h9Z2ktwtNKvIdIEu137rjYbcb9ApSbVJfWxANNuiKTD/9tOKjK9qOA==",
+            "version": "6.9.0",
+            "resolved": "https://registry.npmjs.org/eslint-plugin-jsx-a11y/-/eslint-plugin-jsx-a11y-6.9.0.tgz",
+            "integrity": "sha512-nOFOCaJG2pYqORjK19lqPqxMO/JpvdCZdPtNdxY3kvom3jTvkAbOvQvD8wuD0G8BYR0IGAGYDlzqWJOh/ybn2g==",
+            "license": "MIT",
             "dependencies": {
-                "@babel/runtime": "^7.23.2",
-                "aria-query": "^5.3.0",
-                "array-includes": "^3.1.7",
+                "aria-query": "~5.1.3",
+                "array-includes": "^3.1.8",
                 "array.prototype.flatmap": "^1.3.2",
                 "ast-types-flow": "^0.0.8",
-                "axe-core": "=4.7.0",
-                "axobject-query": "^3.2.1",
+                "axe-core": "^4.9.1",
+                "axobject-query": "~3.1.1",
                 "damerau-levenshtein": "^1.0.8",
                 "emoji-regex": "^9.2.2",
-                "es-iterator-helpers": "^1.0.15",
-                "hasown": "^2.0.0",
+                "es-iterator-helpers": "^1.0.19",
+                "hasown": "^2.0.2",
                 "jsx-ast-utils": "^3.3.5",
                 "language-tags": "^1.0.9",
                 "minimatch": "^3.1.2",
-                "object.entries": "^1.1.7",
-                "object.fromentries": "^2.0.7"
+                "object.fromentries": "^2.0.8",
+                "safe-regex-test": "^1.0.3",
+                "string.prototype.includes": "^2.0.0"
             },
             "engines": {
                 "node": ">=4.0"
             },
             "peerDependencies": {
                 "eslint": "^3 || ^4 || ^5 || ^6 || ^7 || ^8"
+            }
+        },
+        "node_modules/eslint-plugin-jsx-a11y/node_modules/aria-query": {
+            "version": "5.1.3",
+            "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.1.3.tgz",
+            "integrity": "sha512-R5iJ5lkuHybztUfuOAznmboyjWq8O6sqNqtK7CLOqdydi54VNbORp49mb14KbWgG1QD3JFO9hJdZ+y4KutfdOQ==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "deep-equal": "^2.0.5"
+            }
+        },
+        "node_modules/eslint-plugin-jsx-a11y/node_modules/axobject-query": {
+            "version": "3.1.1",
+            "resolved": "https://registry.npmjs.org/axobject-query/-/axobject-query-3.1.1.tgz",
+            "integrity": "sha512-goKlv8DZrK9hUh975fnHzhNIO4jUnFCfv/dszV5VwUGDFjI6vQ2VwoyjYjYNEbBE8AH87TduWP5uyDR1D+Iteg==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "deep-equal": "^2.0.5"
             }
         },
         "node_modules/eslint-plugin-prettier": {
@@ -10264,6 +10314,22 @@
             "integrity": "sha512-1qTgH9NG+IIJ4yfKs2e6Pp1bZg8wbDbKHT21HrLIeYBTRLgMYKnMTPAuI3Lcs61nfx5h1xlXnbJtH1kX5/d/ng==",
             "engines": {
                 "node": ">= 10"
+            }
+        },
+        "node_modules/is-arguments": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/is-arguments/-/is-arguments-1.1.1.tgz",
+            "integrity": "sha512-8Q7EARjzEnKpt/PCD7e1cgUS0a6X8u5tdSiMqXhojOdoV9TsMsiO+9VLC5vAmO8N7/GmXn7yjR8qnA6bVAEzfA==",
+            "license": "MIT",
+            "dependencies": {
+                "call-bind": "^1.0.2",
+                "has-tostringtag": "^1.0.0"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
             }
         },
         "node_modules/is-array-buffer": {
@@ -12547,6 +12613,22 @@
             "version": "1.13.1",
             "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.1.tgz",
             "integrity": "sha512-5qoj1RUiKOMsCCNLV1CBiPYE10sziTsnmNxkAI/rZhiD63CF7IqdFGC/XzjWjpSgLf0LxXX3bDFIh0E18f6UhQ==",
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/object-is": {
+            "version": "1.1.6",
+            "resolved": "https://registry.npmjs.org/object-is/-/object-is-1.1.6.tgz",
+            "integrity": "sha512-F8cZ+KfGlSGi09lJT7/Nd6KJZ9ygtvYC0/UYYLI9nmQKLMnydpB9yvbv9K1uSkEu7FU9vYPmVwLg328tX+ot3Q==",
+            "license": "MIT",
+            "dependencies": {
+                "call-bind": "^1.0.7",
+                "define-properties": "^1.2.1"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            },
             "funding": {
                 "url": "https://github.com/sponsors/ljharb"
             }
@@ -17105,6 +17187,18 @@
                 "node": ">= 0.8"
             }
         },
+        "node_modules/stop-iteration-iterator": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/stop-iteration-iterator/-/stop-iteration-iterator-1.0.0.tgz",
+            "integrity": "sha512-iCGQj+0l0HOdZ2AEeBADlsRC+vsnDsZsbdSiH1yNSjcfKM7fdpCMfqAL/dwF5BLiw/XhRft/Wax6zQbhq2BcjQ==",
+            "license": "MIT",
+            "dependencies": {
+                "internal-slot": "^1.0.4"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            }
+        },
         "node_modules/string_decoder": {
             "version": "1.1.1",
             "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
@@ -17147,6 +17241,16 @@
             "version": "8.0.0",
             "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
             "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="
+        },
+        "node_modules/string.prototype.includes": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/string.prototype.includes/-/string.prototype.includes-2.0.0.tgz",
+            "integrity": "sha512-E34CkBgyeqNDcrbU76cDjL5JLcVrtSdYq0MEh/B10r17pRP4ciHLwTgnuLV8Ay6cgEMLkcBkFCKyFZ43YldYzg==",
+            "license": "MIT",
+            "dependencies": {
+                "define-properties": "^1.1.3",
+                "es-abstract": "^1.17.5"
+            }
         },
         "node_modules/string.prototype.matchall": {
             "version": "4.0.8",

--- a/package-lock.json
+++ b/package-lock.json
@@ -3244,9 +3244,9 @@
             }
         },
         "node_modules/@reduxjs/toolkit": {
-            "version": "2.2.6",
-            "resolved": "https://registry.npmjs.org/@reduxjs/toolkit/-/toolkit-2.2.6.tgz",
-            "integrity": "sha512-kH0r495c5z1t0g796eDQAkYbEQ3a1OLYN9o8jQQVZyKyw367pfRGS+qZLkHYvFHiUUdafpoSlQ2QYObIApjPWA==",
+            "version": "2.2.7",
+            "resolved": "https://registry.npmjs.org/@reduxjs/toolkit/-/toolkit-2.2.7.tgz",
+            "integrity": "sha512-faI3cZbSdFb8yv9dhDTmGwclW0vk0z5o1cia+kf7gCbaCwHI5e+7tP57mJUv22pNcNbeA62GSrPpfrUfdXcQ6g==",
             "license": "MIT",
             "dependencies": {
                 "immer": "^10.0.3",
@@ -3275,15 +3275,6 @@
             "funding": {
                 "type": "opencollective",
                 "url": "https://opencollective.com/immer"
-            }
-        },
-        "node_modules/@reduxjs/toolkit/node_modules/redux-thunk": {
-            "version": "3.1.0",
-            "resolved": "https://registry.npmjs.org/redux-thunk/-/redux-thunk-3.1.0.tgz",
-            "integrity": "sha512-NW2r5T6ksUKXCabzhL9z+h206HQw/NJkcLm1GPImRQ8IzfXwRGqjVhKJGauHirT0DAuyy6hjdnMZaRoAcy0Klw==",
-            "license": "MIT",
-            "peerDependencies": {
-                "redux": "^5.0.0"
             }
         },
         "node_modules/@remix-run/router": {
@@ -15996,6 +15987,15 @@
             "peerDependencies": {
                 "redux": ">=5 <6",
                 "rxjs": ">=7 <8"
+            }
+        },
+        "node_modules/redux-thunk": {
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/redux-thunk/-/redux-thunk-3.1.0.tgz",
+            "integrity": "sha512-NW2r5T6ksUKXCabzhL9z+h206HQw/NJkcLm1GPImRQ8IzfXwRGqjVhKJGauHirT0DAuyy6hjdnMZaRoAcy0Klw==",
+            "license": "MIT",
+            "peerDependencies": {
+                "redux": "^5.0.0"
             }
         },
         "node_modules/reflect-metadata": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -16512,9 +16512,10 @@
             "integrity": "sha512-ZRwKbh/eQ6w9vmTjkuG0Ioi3HBwPFce0O+v//ve+aOq1oeCy7jMV2qzzAlpsNuqpqCBjjriM1lbtZbF/Q8jVyA=="
         },
         "node_modules/sass": {
-            "version": "1.74.1",
-            "resolved": "https://registry.npmjs.org/sass/-/sass-1.74.1.tgz",
-            "integrity": "sha512-w0Z9p/rWZWelb88ISOLyvqTWGmtmu2QJICqDBGyNnfG4OUnPX9BBjjYIXUpXCMOOg5MQWNpqzt876la1fsTvUA==",
+            "version": "1.77.8",
+            "resolved": "https://registry.npmjs.org/sass/-/sass-1.77.8.tgz",
+            "integrity": "sha512-4UHg6prsrycW20fqLGPShtEvo/WyHRVRHwOP4DzkUrObWoWI05QBSfzU71TVB7PFaL104TwNaHpjlWXAZbQiNQ==",
+            "license": "MIT",
             "dependencies": {
                 "chokidar": ">=3.0.0 <4.0.0",
                 "immutable": "^4.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -4040,9 +4040,10 @@
             "integrity": "sha512-Y4XFY5VJAuw0FgAqPNd6NNoV44jbq9Bz2L7Rh/J6jLTiHBSBJa9fxqQIvkIld4GsoDOcCbvzOUAbLPsSKKg+uA=="
         },
         "node_modules/@types/node": {
-            "version": "20.12.7",
-            "resolved": "https://registry.npmjs.org/@types/node/-/node-20.12.7.tgz",
-            "integrity": "sha512-wq0cICSkRLVaf3UGLMGItu/PtdY7oaXaI/RVU+xliKVOtRna3PRY57ZDfztpDL0n11vfymMUnXv8QwYCO7L1wg==",
+            "version": "20.14.14",
+            "resolved": "https://registry.npmjs.org/@types/node/-/node-20.14.14.tgz",
+            "integrity": "sha512-d64f00982fS9YoOgJkAMolK7MN8Iq3TDdVjchbYHdEmjth/DHowx82GnoA+tVUAN+7vxfYUgAzi+JXbKNd2SDQ==",
+            "license": "MIT",
             "dependencies": {
                 "undici-types": "~5.26.4"
             }

--- a/package-lock.json
+++ b/package-lock.json
@@ -9812,9 +9812,10 @@
             }
         },
         "node_modules/html-dom-parser": {
-            "version": "5.0.8",
-            "resolved": "https://registry.npmjs.org/html-dom-parser/-/html-dom-parser-5.0.8.tgz",
-            "integrity": "sha512-vuWiX9EXgu8CJ5m9EP5c7bvBmNSuQVnrY8tl0z0ZX96Uth1IPlYH/8W8VZ/hBajFf18EN+j2pukbCNd01HEd1w==",
+            "version": "5.0.9",
+            "resolved": "https://registry.npmjs.org/html-dom-parser/-/html-dom-parser-5.0.9.tgz",
+            "integrity": "sha512-QGeoFYwgQ582EDvrBx0+ejIz76/LuQcwwkmSR4ueKncjl2yWbciA45Kfz/LrHvWR3CgtKnxKFkr4Mpq2Sh1QNg==",
+            "license": "MIT",
             "dependencies": {
                 "domhandler": "5.0.3",
                 "htmlparser2": "9.1.0"
@@ -9862,17 +9863,18 @@
             }
         },
         "node_modules/html-react-parser": {
-            "version": "5.1.10",
-            "resolved": "https://registry.npmjs.org/html-react-parser/-/html-react-parser-5.1.10.tgz",
-            "integrity": "sha512-gV22PvLij4wdEdtrZbGVC7Zy2OVWnQ0bYhX63S196ZRSx4+K0TuutCreHSXr+saUia8KeKB+2TYziVfijpH4Tw==",
+            "version": "5.1.12",
+            "resolved": "https://registry.npmjs.org/html-react-parser/-/html-react-parser-5.1.12.tgz",
+            "integrity": "sha512-OPv8fsIvxxv/+pLj9mYvyNu8PE5dPMowTRdd5VHpcoZpXlstp8eYCxQ5rzqAE5Tb75rhdiWUXnPltfb62zCVjg==",
+            "license": "MIT",
             "dependencies": {
                 "domhandler": "5.0.3",
-                "html-dom-parser": "5.0.8",
+                "html-dom-parser": "5.0.9",
                 "react-property": "2.0.2",
                 "style-to-js": "1.1.12"
             },
             "peerDependencies": {
-                "@types/react": "17 || 18",
+                "@types/react": "0.14 || 15 || 16 || 17 || 18",
                 "react": "0.14 || 15 || 16 || 17 || 18"
             },
             "peerDependenciesMeta": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -14606,9 +14606,10 @@
             }
         },
         "node_modules/react-cron-generator": {
-            "version": "2.0.11",
-            "resolved": "https://registry.npmjs.org/react-cron-generator/-/react-cron-generator-2.0.11.tgz",
-            "integrity": "sha512-P0PmgYz/KKcD5w/OBX/ZjwyvY36I/nngM9BwVZ2GayAkD+bvzuidzXNY6L9mzQYhS0UgtEc58Bxn5JKVFhQdng==",
+            "version": "2.0.12",
+            "resolved": "https://registry.npmjs.org/react-cron-generator/-/react-cron-generator-2.0.12.tgz",
+            "integrity": "sha512-c94XpFb5sVjKN7tYe/6nSFPy/wjHk3AGX1LGo4W9tacndUTEPcXvsXOTKW7Jc39iwfCsswc7XTUEOIEmdYxq/Q==",
+            "license": "ISC",
             "dependencies": {
                 "cronstrue": "^2.12.0"
             },

--- a/package-lock.json
+++ b/package-lock.json
@@ -2298,10 +2298,11 @@
             }
         },
         "node_modules/@cypress/request": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/@cypress/request/-/request-3.0.0.tgz",
-            "integrity": "sha512-GKFCqwZwMYmL3IBoNeR2MM1SnxRIGERsQOTWeQKoYBt2JLqcqiy7JXqO894FLrpjZYqGxW92MNwRH2BN56obdQ==",
+            "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/@cypress/request/-/request-3.0.1.tgz",
+            "integrity": "sha512-TWivJlJi8ZDx2wGOw1dbLuHJKUYX7bWySw377nlnGOW3hP9/MUKIsEdXT/YngWxVdgNCHRBmFlBipE+5/2ZZlQ==",
             "dev": true,
+            "license": "Apache-2.0",
             "dependencies": {
                 "aws-sign2": "~0.7.0",
                 "aws4": "^1.8.0",
@@ -2316,7 +2317,7 @@
                 "json-stringify-safe": "~5.0.1",
                 "mime-types": "~2.1.19",
                 "performance-now": "^2.1.0",
-                "qs": "~6.10.3",
+                "qs": "6.10.4",
                 "safe-buffer": "^5.1.2",
                 "tough-cookie": "^4.1.3",
                 "tunnel-agent": "^0.6.0",
@@ -6917,14 +6918,14 @@
             "integrity": "sha512-DJR/VvkAvSZW9bTouZue2sSxDwdTN92uHjqeKVm+0dAqdfNykRzQ95tay8aXMBAAPpUiq4Qcug2L7neoRh2Egw=="
         },
         "node_modules/cypress": {
-            "version": "13.13.1",
-            "resolved": "https://registry.npmjs.org/cypress/-/cypress-13.13.1.tgz",
-            "integrity": "sha512-8F9UjL5MDUdgC/S5hr8CGLHbS5gGht5UOV184qc2pFny43fnkoaKxlzH/U6//zmGu/xRTaKimNfjknLT8+UDFg==",
+            "version": "13.13.2",
+            "resolved": "https://registry.npmjs.org/cypress/-/cypress-13.13.2.tgz",
+            "integrity": "sha512-PvJQU33933NvS1StfzEb8/mu2kMy4dABwCF+yd5Bi7Qly1HOVf+Bufrygee/tlmty/6j5lX+KIi8j9Q3JUMbhA==",
             "dev": true,
             "hasInstallScript": true,
             "license": "MIT",
             "dependencies": {
-                "@cypress/request": "^3.0.0",
+                "@cypress/request": "^3.0.1",
                 "@cypress/xvfb": "^1.2.4",
                 "@types/sinonjs__fake-timers": "8.1.1",
                 "@types/sizzle": "^2.3.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -42,7 +42,7 @@
                 "react-router-dom": "^6.9.0",
                 "react-scripts": "^5.0.1",
                 "react-select": "^5.7.2",
-                "react-simple-code-editor": "^0.13.1",
+                "react-simple-code-editor": "^0.14.0",
                 "reactflow": "^11.7.2",
                 "reactstrap": "^9.1.6",
                 "redux-observable": "^3.0.0-rc.2",
@@ -15956,12 +15956,13 @@
             }
         },
         "node_modules/react-simple-code-editor": {
-            "version": "0.13.1",
-            "resolved": "https://registry.npmjs.org/react-simple-code-editor/-/react-simple-code-editor-0.13.1.tgz",
-            "integrity": "sha512-XYeVwRZwgyKtjNIYcAEgg2FaQcCZwhbarnkJIV20U2wkCU9q/CPFBo8nRXrK4GXUz3AvbqZFsZRrpUTkqqEYyQ==",
+            "version": "0.14.1",
+            "resolved": "https://registry.npmjs.org/react-simple-code-editor/-/react-simple-code-editor-0.14.1.tgz",
+            "integrity": "sha512-BR5DtNRy+AswWJECyA17qhUDvrrCZ6zXOCfkQY5zSmb96BVUbpVAv03WpcjcwtCwiLbIANx3gebHOcXYn1EHow==",
+            "license": "MIT",
             "peerDependencies": {
-                "react": "*",
-                "react-dom": "*"
+                "react": ">=16.8.0",
+                "react-dom": ">=16.8.0"
             }
         },
         "node_modules/react-transition-group": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -7653,9 +7653,10 @@
             }
         },
         "node_modules/dompurify": {
-            "version": "3.1.0",
-            "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.1.0.tgz",
-            "integrity": "sha512-yoU4rhgPKCo+p5UrWWWNKiIq+ToGqmVVhk0PmMYBK4kRsR3/qhemNFL8f6CFmBd4gMwm3F4T7HBoydP5uY07fA=="
+            "version": "3.1.6",
+            "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.1.6.tgz",
+            "integrity": "sha512-cTOAhc36AalkjtBpfG6O8JimdTMWNXjiePT2xQH/ppBGi/4uIpmj8eKyIkMJErXWARyINV/sB38yf8JCLF5pbQ==",
+            "license": "(MPL-2.0 OR Apache-2.0)"
         },
         "node_modules/domutils": {
             "version": "3.1.0",

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
         "react-router-dom": "^6.9.0",
         "react-scripts": "^5.0.1",
         "react-select": "^5.7.2",
-        "react-simple-code-editor": "^0.13.1",
+        "react-simple-code-editor": "^0.14.0",
         "reactflow": "^11.7.2",
         "reactstrap": "^9.1.6",
         "redux-observable": "^3.0.0-rc.2",


### PR DESCRIPTION
Update dependencies reported by Renovate:

[Update dependency @reduxjs/toolkit to v2.2.7](https://github.com/CZERTAINLY/CZERTAINLY-FE-Administrator/pull/746)
[Update dependency @types/node to v20.14.14](https://github.com/CZERTAINLY/CZERTAINLY-FE-Administrator/pull/748)
[Update dependency cronstrue to v2.50.0](https://github.com/CZERTAINLY/CZERTAINLY-FE-Administrator/pull/749)
[Update dependency cypress to v13.13.2](https://github.com/CZERTAINLY/CZERTAINLY-FE-Administrator/pull/747)
[Update dependency dompurify to v3.1.6](https://github.com/CZERTAINLY/CZERTAINLY-FE-Administrator/pull/676)
[Update dependency eslint-plugin-jsx-a11y to v6.9.0](https://github.com/CZERTAINLY/CZERTAINLY-FE-Administrator/pull/750)
[Update dependency eslint-plugin-prettier to v5.2.1](https://github.com/CZERTAINLY/CZERTAINLY-FE-Administrator/pull/751)
[Update dependency highlight.js to v11.10.0](https://github.com/CZERTAINLY/CZERTAINLY-FE-Administrator/pull/752)
[Update dependency html-react-parser to v5.1.12](https://github.com/CZERTAINLY/CZERTAINLY-FE-Administrator/pull/735)
[Update dependency husky to v9.1.4](https://github.com/CZERTAINLY/CZERTAINLY-FE-Administrator/pull/753)
[Update dependency react-cron-generator to v2.0.12](https://github.com/CZERTAINLY/CZERTAINLY-FE-Administrator/pull/741)
[Update dependency react-simple-code-editor to ^0.14.0](https://github.com/CZERTAINLY/CZERTAINLY-FE-Administrator/pull/754)
[Update dependency sass to v1.77.8](https://github.com/CZERTAINLY/CZERTAINLY-FE-Administrator/pull/664)

[Update docker/build-push-action action to v6](https://github.com/CZERTAINLY/CZERTAINLY-FE-Administrator/pull/757)
[Update sigstore/cosign-installer action to v3.6.0](https://github.com/CZERTAINLY/CZERTAINLY-FE-Administrator/pull/761)