### PR TITLE
Make badge responsive

### DIFF
--- a/src/resources/styles/_overrides.scss
+++ b/src/resources/styles/_overrides.scss
@@ -168,6 +168,11 @@
 
 .badge {
     font-size: 12px;
+    word-break: break-all;
+    display: inline-block;
+    white-space: normal;
+    overflow-wrap: break-word;
+    text-align: left;
 
     .list-group-item > & {
         margin-top: 2px;


### PR DESCRIPTION
This is fix for open [issue-803](https://github.com/CZERTAINLY/CZERTAINLY-FE-Administrator/issues/803).

Before
<img width="1413" alt="Screenshot 294" src="https://github.com/user-attachments/assets/517d6265-0302-4164-a3c6-bf370500ee2b" />


After the fix
<img width="1412" alt="Screenshot 295" src="https://github.com/user-attachments/assets/fcc11cd7-26c8-44e5-82a4-59895513a30b" />
