### PR TITLE
Fix duplicated recipient type badge text

### DIFF
--- a/src/components/_pages/notifications/notification-profiles/detail/index.tsx
+++ b/src/components/_pages/notifications/notification-profiles/detail/index.tsx
@@ -129,7 +129,6 @@ export default function NotificationProfileDetail() {
                               'Recipient Type',
                               <Badge key="recipientType" color="secondary">
                                   {getEnumLabel(recipientTypeEnum, notificationProfile.recipientType)}
-                                  {getEnumLabel(recipientTypeEnum, notificationProfile.recipientType)}
                               </Badge>,
                           ],
                       },


### PR DESCRIPTION
## Summary
- remove duplicate getEnumLabel call in Notification Profile detail page

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_684943c99dfc832d94773d3033d0b2a4