### PR TITLE
Double API calls fix

### DIFF
--- a/src/components/_pages/actions/list/index.tsx
+++ b/src/components/_pages/actions/list/index.tsx
@@ -20,6 +20,7 @@ const RulesList = () => {
             <>
                 <TabLayout
                     selectedTab={activeTab}
+                    onlyActiveTabContent
                     tabs={[
                         {
                             title: 'Actions',

--- a/src/components/_pages/ra-profiles/detail/index.tsx
+++ b/src/components/_pages/ra-profiles/detail/index.tsx
@@ -132,7 +132,7 @@ export default function RaProfileDetail() {
     );
 
     const getFreshRaProfileDetail = useCallback(() => {
-        if (!id || !authorityId) {
+        if (!id || !authorityId || authorityId === 'undefined') {
             return;
         }
         if (authorityId === 'unknown') {
@@ -188,23 +188,6 @@ export default function RaProfileDetail() {
 
         dispatch(settingsActions.getPlatformSettings());
     }, [dispatch, platformSettings]);
-
-    useEffect(() => {
-        if (!id || !authorityId || authorityId === 'undefined') {
-            return;
-        }
-
-        if (authorityId === 'unknown') {
-            dispatch(raProfilesActions.getRaProfileWithoutAuthority({ uuid: id }));
-        } else {
-            dispatch(raProfilesActions.getRaProfileDetail({ authorityUuid: authorityId, uuid: id }));
-        }
-    }, [id, dispatch, authorityId]);
-
-    useEffect(() => {
-        if (!id) return;
-        dispatch(complianceProfileActions.getAssociatedComplianceProfiles({ resource: Resource.RaProfiles, associationObjectUuid: id }));
-    }, [id, dispatch]);
 
     // use effect to clear the ra profile detail when the component is unmounted
     useEffect(() => {

--- a/src/components/_pages/rules/list/index.tsx
+++ b/src/components/_pages/rules/list/index.tsx
@@ -20,6 +20,7 @@ const RulesList = () => {
             <>
                 <TabLayout
                     selectedTab={activeTab}
+                    onlyActiveTabContent
                     tabs={[
                         {
                             title: 'Rules',


### PR DESCRIPTION
- Prevent double getResources calls by adding 'onlyActiveTabContent' prop to TabLayout in Rules list and Actions list
- Refactor RaProfileDetail component to remove redundant useEffect hooks for fetching profile details